### PR TITLE
Use nodejs:12.16.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN apt-get update \
     && go get github.com/rubenv/sql-migrate/... \
     && go get github.com/gostaticanalysis/nilerr/cmd/nilerr \
     && curl -L git.io/nodebrew | perl - setup \
-    && $HOME/.nodebrew/current/bin/nodebrew install-binary v12.13.0 \
-    && $HOME/.nodebrew/current/bin/nodebrew use v12.13.0 \
+    && $HOME/.nodebrew/current/bin/nodebrew install-binary v12.16.3 \
+    && $HOME/.nodebrew/current/bin/nodebrew use v12.16.3 \
     && rm -rf /tmp/*

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build -t pacificporter/golang:1.14.2-12.13.0 .
+docker build -t pacificporter/golang:1.14.2-12.16.3 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/golang:1.14.2-12.13.0
+docker push pacificporter/golang:1.14.2-12.16.3
 ```


### PR DESCRIPTION
npm も新しくなっていたため NodeJS を v12.16.3 に上げます。

阿部の権限だと docker push できないようなので、良さそうでしたら push もお願いできますでしょうか。
よろしくお願いします。