### PR TITLE
Use nodejs:14.15.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN apt-get update \
     && go get github.com/rubenv/sql-migrate/... \
     && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0 \
     && curl -L git.io/nodebrew | perl - setup \
-    && $HOME/.nodebrew/current/bin/nodebrew install-binary v12.16.3 \
-    && $HOME/.nodebrew/current/bin/nodebrew use v12.16.3 \
+    && $HOME/.nodebrew/current/bin/nodebrew install-binary v14.15.4 \
+    && $HOME/.nodebrew/current/bin/nodebrew use v14.15.4 \
     && rm -rf /tmp/*

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build -t pacificporter/golang:1.15.6-12.16.3 .
+docker build -t pacificporter/golang:1.15.6-14.15.4 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/golang:1.15.6-12.16.3
+docker push pacificporter/golang:1.15.6-14.15.4
 ```


### PR DESCRIPTION
https://github.com/pacificporter/box-golang-docker/issues/60

docker push をお願いできますでしょうか。

よろしくお願いします。

```sh
$ docker build -t pacificporter/golang:1.15.6-14.15.4 .
# ...
Fetching: https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-x64.tar.gz
######################################################################## 100.0%
Installed successfully
use v14.15.4
Removing intermediate container 4beadabaa609
 ---> 2819cff29cef
Successfully built 2819cff29cef
Successfully tagged pacificporter/golang:1.15.6-14.15.4
```