### PR TITLE
pressly/goose に置き換えた tag を 1.15.6-14.15.4-1 とする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ GOVERSION=$(shell grep FROM Dockerfile | cut -f 2 -d ':')
 
 .PHONY: update_readme
 update_readme:
-	${SEDICMD} "s/golang:.*-/golang:${GOVERSION}-/" README.md
+	${SEDICMD} "s/golang:[^-]\+-/golang:${GOVERSION}-/" README.md

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build -t pacificporter/golang:1.15.6-14.15.4 .
+docker build -t pacificporter/golang:1.15.6-14.15.4-1 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/golang:1.15.6-14.15.4
+docker push pacificporter/golang:1.15.6-14.15.4-1
 ```


### PR DESCRIPTION
タグの更新漏れの対応です。

https://github.com/pacificporter/box-golang-docker/pull/63

よろしくお願いいたします。