### PR TITLE
Remove golangci-lint from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
     && go get github.com/github-release/github-release \
     && go get github.com/pressly/goose/cmd/goose \
     && go get github.com/rubenv/sql-migrate/... \
-    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0 \
     && curl -L git.io/nodebrew | perl - setup \
     && $HOME/.nodebrew/current/bin/nodebrew install-binary v14.15.4 \
     && $HOME/.nodebrew/current/bin/nodebrew use v14.15.4 \


### PR DESCRIPTION
https://github.com/pacificporter/kanzashi2-plan/issues/1931

* golangci-lint を Dockerfile から削除しました
* CI での golangci-lint は GitHub Actions で行うよう変更済みです