### PR TITLE
Bump golang from 1.16.4 to 1.16.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4
+FROM golang:1.16.6
 MAINTAINER HARUYAMA Seigo <haruyama@pacificporter.jp>
 
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build -t pacificporter/golang:1.16.4-14.15.4-2 .
+docker build -t pacificporter/golang:1.16.6-14.15.4-2 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/golang:1.16.4-14.15.4-2
+docker push pacificporter/golang:1.16.6-14.15.4-2
 ```


### PR DESCRIPTION
* docker build & docker push 済みです
    * https://hub.docker.com/layers/pacificporter/golang/1.16.6-14.15.4-2/images/sha256-7a36a87373c518ae37c59e50199ada05bded1b736b403ccc529399b6f9f0b10b?context=repo

