### PR TITLE
aws-cli を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER HARUYAMA Seigo <haruyama@pacificporter.jp>
 ENV DEBCONF_NOWARNINGS yes
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends chromium rsync \
+    && apt-get install -y --no-install-recommends chromium rsync unzip \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/* \
     && go get github.com/github-release/github-release \
@@ -18,4 +18,7 @@ RUN apt-get update \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt update \
-    && apt install gh
+    && apt install gh \
+    && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,5 @@ RUN apt-get update \
     && apt install gh \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
-    && ./aws/install
+    && ./aws/install \
+    && rm -rf ./awscliv2.zip ./aws


### PR DESCRIPTION
GitHub Actions からのデプロイ時に、ビルドした静的ファイルを S3 にコピーするときなどに使いたいため、 aws コマンドを追加しました。手元では `/usr/local/bin/aws` としてインストールされることを確認しております。

apt-get で入るバージョンは古いようなので、現在推奨されている以下の方式でインストールするようにしています。
https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/getting-started-install.html