### PR TITLE
patch コマンドをインストールする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER HARUYAMA Seigo <haruyama@pacificporter.jp>
 ENV DEBCONF_NOWARNINGS yes
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends chromium rsync unzip \
+    && apt-get install -y --no-install-recommends chromium rsync unzip patch \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/* \
     && go get github.com/github-release/github-release \


### PR DESCRIPTION
https://github.com/pacificporter/kanzashi2/commit/89e260ef22900af13867ef5e33ebfa5f39388b2e により patch コマンドの実行を追加しましたが、CI での goa gen の際に patch コマンドがなかったため失敗しました。
https://app.circleci.com/pipelines/github/pacificporter/kanzashi2/5012/workflows/f862ae7b-76de-4d89-a091-87d0fe126f72/jobs/4456
patch コマンドを追加します。

OK そうでしたら下記のブランチにも反映します。

https://github.com/pacificporter/box-golang-docker/tree/1.18.2-14.19.2
https://github.com/pacificporter/box-golang-docker/tree/1.18.2-14.19.3
https://github.com/pacificporter/box-golang-docker/tree/1.18.2-16.15.0