### PR TITLE
1.18.5-14.20.0-2: jq をインストール / gh を GitHub Release からインストール

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ FROM golang:1.18.5
 # `debconf: delaying package configuration, since apt-utils is not installed` を抑止する
 ENV DEBCONF_NOWARNINGS yes
 
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends chromium rsync gh unzip patch \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends chromium rsync unzip patch jq \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/* \
+    && curl -fsSL https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb | dd of=/tmp/gh_2.14.7_linux_amd64.deb \
+    && dpkg -i /tmp/gh_2.14.7_linux_amd64.deb \
     && go install github.com/github-release/github-release@latest \
     && go install github.com/pressly/goose/v3/cmd/goose@latest \
     && go install github.com/rubenv/sql-migrate/...@latest \

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build -t pacificporter/golang:1.18.5-14.20.0 .
+docker build -t pacificporter/golang:1.18.5-14.20.0-2 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/golang:1.18.5-14.20.0
+docker push pacificporter/golang:1.18.5-14.20.0-2
 ```


### PR DESCRIPTION
- https://github.com/cli/cli/issues/6175 のため gh は GitHub の Release からインストールするようにしました
- CircleCI の Slack 通知で jq がない場合インストールして利用していたので, jq を用意するようにしました