### PR TITLE
deps: use golang:1.19.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.6
+FROM golang:1.19.2
 
 # `debconf: delaying package configuration, since apt-utils is not installed` を抑止する
 ENV DEBCONF_NOWARNINGS yes

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build -t pacificporter/golang:1.18.6-14.20.1 .
+docker build -t pacificporter/golang:1.19.2-14.20.1 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/golang:1.18.6-14.20.1
+docker push pacificporter/golang:1.19.2-14.20.1
 ```


### PR DESCRIPTION
cf. Bump golang from 1.18.6 to 1.19.2 #108 
手元で image を作るための作業はしていましたが, push していませんでした