### PR TITLE
git-credential-github-apps をインストールする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
     && go install github.com/github-release/github-release@latest \
     && go install github.com/pressly/goose/v3/cmd/goose@latest \
     && go install github.com/rubenv/sql-migrate/...@latest \
+    && go install github.com/mackee/git-credential-github-apps@latest \
     && curl -L git.io/nodebrew | perl - setup \
     && $HOME/.nodebrew/current/bin/nodebrew install-binary v14.21.2 \
     && $HOME/.nodebrew/current/bin/nodebrew use v14.21.2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
     && rm -rf /var/cache/apt/archives/* \
     && go install github.com/github-release/github-release@latest \
     && go install github.com/pressly/goose/v3/cmd/goose@latest \
-    && go install github.com/rubenv/sql-migrate/...@latest \
     && go install github.com/mackee/git-credential-github-apps@latest \
     && curl -L git.io/nodebrew | perl - setup \
     && $HOME/.nodebrew/current/bin/nodebrew install-binary v14.21.2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends chromium rsync unzip patch jq \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/* \
-    && go install github.com/github-release/github-release@latest \
     && go install github.com/pressly/goose/v3/cmd/goose@latest \
     && go install github.com/mackee/git-credential-github-apps@latest \
     && curl -L git.io/nodebrew | perl - setup \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends chromium rsync unzip patch jq \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/* \
-    && curl -fsSL https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb | dd of=/tmp/gh_2.14.7_linux_amd64.deb \
-    && dpkg -i /tmp/gh_2.14.7_linux_amd64.deb \
     && go install github.com/github-release/github-release@latest \
     && go install github.com/pressly/goose/v3/cmd/goose@latest \
     && go install github.com/rubenv/sql-migrate/...@latest \

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build -t pacificporter/golang:1.19.4-14.21.2 .
+docker build -t pacificporter/golang:1.19.4-14.21.2-2 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/golang:1.19.4-14.21.2
+docker push pacificporter/golang:1.19.4-14.21.2-2
 ```


### PR DESCRIPTION
https://github.com/pacificporter/kanzashi2-plan/issues/1934

* https://github.com/pacificporter/relax/pull/2072 で必要なので追加しました
* gh, sql-migrate, github-release は使われていないようなので削除しました