### PR TITLE
docker build で --platform linux/amd64 を指定する

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build -t pacificporter/golang:1.19.4-14.21.2-2 .
+docker build --platform linux/amd64 -t pacificporter/golang:1.19.4-14.21.2-3 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/golang:1.19.4-14.21.2-2
+docker push pacificporter/golang:1.19.4-14.21.2-3
 ```


### PR DESCRIPTION
* https://github.com/pacificporter/box-golang-docker/pull/117 でプラットフォームが linux/arm64 になってしまっていました
    * Apple Silicon でビルドを行ったため
* docker build で `--platform linux/amd64` を指定するようにしました