### PR TITLE
deps: use node v16.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update \
     && go install github.com/pressly/goose/v3/cmd/goose@latest \
     && go install github.com/mackee/git-credential-github-apps@latest \
     && curl -L git.io/nodebrew | perl - setup \
-    && $HOME/.nodebrew/current/bin/nodebrew install-binary v16.20.0 \
-    && $HOME/.nodebrew/current/bin/nodebrew use v16.20.0 \
+    && $HOME/.nodebrew/current/bin/nodebrew install-binary v16.20.1 \
+    && $HOME/.nodebrew/current/bin/nodebrew use v16.20.1 \
     && rm -rf /tmp/* \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## build
 
 ```
-docker build --platform linux/amd64 -t pacificporter/golang:1.20.5-16.20.0 .
+docker build --platform linux/amd64 -t pacificporter/golang:1.20.5-16.20.1 .
 ```
 
 ## push
 
 ```
-docker push pacificporter/golang:1.20.5-16.20.0
+docker push pacificporter/golang:1.20.5-16.20.1
 ```


### PR DESCRIPTION
https://nodejs.org/en/blog/release/v16.20.1

docker push 済みです。

よろしくお願いします。